### PR TITLE
[ODS-28] feat: chore: main/dev docker compose 환경 분리

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+# docker-compose.dev.yml
+services:
+  app:
+    image: 1d1s/oneday-onestreak:${TAG}
+    container_name: oneday-onestreak-dev
+    ports:
+      - "127.0.0.1:18081:8080"
+    restart: always
+    volumes:
+      - /var/log/oneday:/app/logs
+    env_file:
+      - .env/docker.dev.env

--- a/docker-compose.main.yml
+++ b/docker-compose.main.yml
@@ -1,12 +1,12 @@
-# docker-compose.prod.yml
+# docker-compose.main.yml
 services:
   app:
     image: 1d1s/oneday-onestreak:${TAG}
-    container_name: oneday-onestreak-prod
+    container_name: oneday-onestreak-main
     ports:
-      - "8080:8080"
+      - "127.0.0.1:18080:8080"
     restart: always
     volumes:
       - /var/log/oneday:/app/logs
     env_file:
-      - .env/docker.pord.env
+      - .env/docker.main.env


### PR DESCRIPTION
## 연관된 이슈
> #59 


## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- main과 dev 환경을 분리하여 동일 EC2 인스턴스에서 동시에 배포할 수 있도록 docker-compose 구조를 개선하였습니다.
- main, dev, local 환경별로 docker-compose 파일과 env 파일을 각각 분리하였으며, 포트 충돌이 발생하지 않도록 호스트 포트를 다르게 설정하였습니다.

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- 요청사항


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 


