### PR TITLE
[ODS-37] feat: fix: CORS 허용 도메인 추가 및 전체 API 경로에 적용

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/config/SecurityConfig.java
+++ b/src/main/java/com/odos/odos_server_v2/config/SecurityConfig.java
@@ -1,7 +1,11 @@
 package com.odos.odos_server_v2.config;
 
+import com.odos.odos_server_v2.domain.security.jwt.JwtAuthenticationFilter;
+import com.odos.odos_server_v2.domain.security.jwt.JwtTokenExceptionFilter;
+import com.odos.odos_server_v2.domain.security.oauth2.handler.OAuth2LoginFailureHandler;
+import com.odos.odos_server_v2.domain.security.oauth2.handler.OAuth2LoginSuccessHandler;
+import com.odos.odos_server_v2.domain.security.oauth2.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,12 +17,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import com.odos.odos_server_v2.domain.security.jwt.JwtAuthenticationFilter;
-import com.odos.odos_server_v2.domain.security.jwt.JwtTokenExceptionFilter;
-import com.odos.odos_server_v2.domain.security.oauth2.handler.OAuth2LoginFailureHandler;
-import com.odos.odos_server_v2.domain.security.oauth2.handler.OAuth2LoginSuccessHandler;
-import com.odos.odos_server_v2.domain.security.oauth2.service.CustomOAuth2UserService;
 
 @Configuration
 @EnableWebSecurity


### PR DESCRIPTION
## 연관된 이슈
> #68 


## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- CORS 적용 범위를 /oauth/** → /**로 확대하여 전체 API에 적용
- https://*.1day1streak.com 패턴으로 서브도메인(dev/local 등) 확장 가능하게 함
- https://1day1streak.com, https://dev.1day1streak.com, https://local.dev.1day1streak.com, https://local.1day1streak.com 추가
- 로컬 개발 편의용으로 http://localhost:*도 옵션으로 허용

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- 요청사항


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 


