### PR TITLE
[ODS-51] fix: diary random API 경로 security config의 permit all 리스트에 추가

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/config/SecurityConfig.java
+++ b/src/main/java/com/odos/odos_server_v2/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                         "/css/**",
                         "/js/**",
                         "/challenges/random",
+                        "/diaries/random",
                         "/swagger",
                         "/swagger-ui.html",
                         "/swagger-ui/**",

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
@@ -265,11 +265,6 @@ public class DiaryService {
   @Transactional
   public List<DiaryResponse> getRandomDiaries(Long size) {
     try {
-      Long memberId = CurrentUserContext.getCurrentMemberId();
-      Member member =
-          memberRepository
-              .findById(memberId)
-              .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
       List<Diary> diaries = diaryRepository.findDiariesByIsPublic(Boolean.TRUE);
       if (diaries.isEmpty()) {
@@ -282,9 +277,10 @@ public class DiaryService {
           .map(
               diary ->
                   DiaryResponse.from(
-                      member,
+                      diary.getMember(),
                       diary,
-                      challengeService.toChallengeSummary(diary.getChallenge(), memberId)))
+                      challengeService.toChallengeSummary(
+                          diary.getChallenge(), diary.getMember().getId())))
           .toList();
     } catch (CustomException e) {
       return Collections.emptyList();


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, (#이슈번호, ...)
- closes #83 

## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- security config에서 해당 API 경로 permit all() 처리
- diaryService에서 로그인한 멤버 Id 검증하지 않게 수정 

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- 요청사항


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 


