### PR TITLE
[ODS-62] 일지 생성/조회 시 goalId 불일치 수정 

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/domain/diary/dto/DiaryGoalDto.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/dto/DiaryGoalDto.java
@@ -7,14 +7,14 @@ import lombok.Getter;
 @Getter
 @Builder
 public class DiaryGoalDto {
-  private Long goalId;
-  private String goalName;
+  private Long challengeGoalId;
+  private String challengeGoalName;
   private Boolean isAchieved;
 
   public static DiaryGoalDto from(DiaryGoal goal) {
     return DiaryGoalDto.builder()
-        .goalId(goal.getId())
-        .goalName(goal.getChallengeGoal().getContent())
+        .challengeGoalId(goal.getChallengeGoal().getId())
+        .challengeGoalName(goal.getChallengeGoal().getContent())
         .isAchieved(goal.getIsCompleted())
         .build();
   }


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, (#이슈번호, ...)
- closes #92 

## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- DiaryResponse 안에 있는 DiaryGoalDto를 수정함 
- 기존에서는 일지 생성 req에서 challengeGoalId로 요청 후 DiaryGoalDto에서 DiaryGoalId로 리턴됨 
=> 모두 challengeGoalId로 리턴되도록 수정 

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- dto의 response변수명이 수정되었습니다. (프론트에서 확인)
1) goalId => challengeGoalId
2) goalName -> challengeGoalName


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated goal field naming conventions to better clarify challenge goal associations in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->