### PR TITLE
[ODS-88] 3일이내로 작성한 다이어리 없어도 예외처리 없애고-> 빈 리스트 반환으로 수정

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/challenge/service/ChallengeService.java
@@ -450,9 +450,6 @@ public class ChallengeService {
     LocalDate twoDaysAgo = today.minusDays(2);
     List<Diary> diaries =
         diaryRepository.findDiariesByDateRange(twoDaysAgo, today, challengeId, currentMemberId);
-    if (diaries.isEmpty()) {
-      throw new CustomException(ErrorCode.DIARY_WRITTEN_IN_3DAYS_NOT_EXIST);
-    }
     return DiaryStreakResponse.checkStreak(diaries);
   }
 }

--- a/src/main/java/com/odos/odos_server_v2/exception/ErrorCode.java
+++ b/src/main/java/com/odos/odos_server_v2/exception/ErrorCode.java
@@ -32,7 +32,6 @@ public enum ErrorCode {
   DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY-002", "존재하지 않는 다이어리입니다."),
   DIARYLIKE_ALREADY_EXISTS(HttpStatus.NOT_FOUND, "DIARY-003", "이미 좋아요를 눌렀습니다. 좋아요는 한번만 누르기 가능합니다"),
   DIARYLIKE_NOT_EXISTS(HttpStatus.NOT_FOUND, "DIARY-004", "좋아요 누른 전적이 없습니다. 새로 좋아요를 눌러주세요"),
-  DIARY_WRITTEN_IN_3DAYS_NOT_EXIST(HttpStatus.NOT_FOUND, "DIARY-006", "3일 이내로 작성한 일지가 없습니다."),
 
   // challenge
   CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE_001", "챌린지를 찾을 수 없습니다."),


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, (#이슈번호, ...)
#98  <- 해당 이슈에서 예외처리한 부분 수정 

## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- 백에서 예외를 던지고 처리해서 프론트에서 에러 화면이 떠서 해결 

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항

## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved error handling for diary streak queries — the app now gracefully handles cases when no diary entries are found in the specified timeframe instead of displaying an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->