### PR TITLE
[ODS-120] 마이페이지 정보에 이메일과 회원가입 플랫폼 정보 추가

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/domain/member/controller/MemberController.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/controller/MemberController.java
@@ -43,6 +43,8 @@ public class MemberController {
                               "data": {
                                 "nickname": "홍길동",
                                 "profileUrl": "https://example.com/profile.jpg",
+                                "email" : "1day1streak@naver.com",
+                                "provider": "NAVER",
                                 "streak": {
                                   "todayGoalCount": 3,
                                   "currentStreak": 5,

--- a/src/main/java/com/odos/odos_server_v2/domain/member/dto/MyPageDto.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/dto/MyPageDto.java
@@ -18,6 +18,12 @@ public class MyPageDto {
   @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
   String profileUrl;
 
+  @Schema(description = "로그인 유저의 이메일 주소", example = "1day1streak@naver.com")
+  String email;
+
+  @Schema(description = "회원가입 플랫폼", example = "NAVER")
+  String provider;
+
   @Schema(description = "스트릭 통계 정보")
   StreakDto streak;
 

--- a/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberService.java
@@ -69,6 +69,8 @@ public class MemberService {
     return MyPageDto.builder()
         .nickname(member.getNickname())
         .profileUrl(imageService.getFileUrl(member.getProfileUrl()))
+        .email(member.getEmail())
+        .provider(member.getSignupRoute().name())
         .streak(getStreakByMemberId(id))
         .challengeList(challengeService.getMemberChallenge(id, id))
         .diaryList(diaryService.getMyDiaries())


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, (#이슈번호, ...)
- closes #111 

## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- 해당 API Response 내용에 이메일과 provider를 추가하였습니다. 

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- 요청사항


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The my-page endpoint has been enhanced with two additional user profile fields. Users can now view their registered email address and the signup provider they used when creating their account. This allows for easy verification of account details and provides a comprehensive view of registration information in one location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->