### PR TITLE
[ODS-131] 기존 고정형 챌린지 참여자와 호스트의 challengeGoalId가 같도록 DB 내용 수정 쿼리 작성

### DIFF
--- a/src/main/resources/db/migration/V4__fixed_challengeType_diary_goal.sql
+++ b/src/main/resources/db/migration/V4__fixed_challengeType_diary_goal.sql
@@ -1,0 +1,32 @@
+UPDATE diary_goal dg
+
+    JOIN diary d
+    ON d.id = dg.diary_id
+
+    JOIN challenge c
+    ON c.id = d.challenge_id
+
+    JOIN challenge_goal cur_g
+    ON cur_g.id = dg.challenge_goal_id
+
+    JOIN participant cur_p
+    ON cur_p.id = cur_g.participant_id
+    AND cur_p.challenge_id = d.challenge_id
+    AND cur_p.member_id = d.member_id
+
+    JOIN participant host_p
+    ON host_p.challenge_id = c.id
+    AND host_p.member_id = c.host_member_id
+    AND host_p.status = 'HOST'
+
+    JOIN challenge_goal host_g
+    ON host_g.participant_id = host_p.id
+    AND host_g.content = cur_g.content
+
+SET dg.challenge_goal_id = host_g.id
+
+WHERE c.type = 'FIXED'
+  AND c.start_date BETWEEN '2026-03-16' AND '2026-03-21'
+  AND d.created_date >= '2026-03-16 00:00:00'
+  AND d.created_date <  '2026-03-21 00:00:00'
+  AND dg.challenge_goal_id <> host_g.id;


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, (#이슈번호, ...)
- closese #123 

## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- 운영서버 db를 로컬db로 복사하여 로컬에서 쿼리 작성 후 테스트하여 최종 쿼리 작성 
- 돌려보고 데이터가 잘 바뀜을 확인해 pr 날립니다. 

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- 요청사항


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected goal associations for diary entries linked to FIXED-type challenges within a specific date range. This ensures accurate goal tracking and consistency across challenge activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->