### PR TITLE
[ODS-131] fix: created_date -> created_at으로 변경 

### DIFF
--- a/src/main/resources/db/migration/V4__fixed_challengeType_diary_goal.sql
+++ b/src/main/resources/db/migration/V4__fixed_challengeType_diary_goal.sql
@@ -27,6 +27,6 @@ SET dg.challenge_goal_id = host_g.id
 
 WHERE c.type = 'FIXED'
   AND c.start_date BETWEEN '2026-03-16' AND '2026-03-21'
-  AND d.created_date >= '2026-03-16 00:00:00'
-  AND d.created_date <  '2026-03-21 00:00:00'
+  AND d.created_at >= '2026-03-16 00:00:00'
+  AND d.created_at <  '2026-03-21 00:00:00'
   AND dg.challenge_goal_id <> host_g.id;


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, (#이슈번호, ...)

- flyway 실패로 칼럼명 변경 

## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- ide에서 빨간색으로 되어도 기준은 항상 db의 칼럼명
- Flyway 문서상 실패한 migration이 Schema History Table에 Failed로 남아 있으면, “repaired” 되기 전까지는 migrate를 다시 진행할 수 없음 -> db에서 해당 행을 삭제하면 자동으로 repair가 되면서 (코드가 성공이면) success으로 변한다. 

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- 요청사항


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed diary entry filtering to correctly identify and retrieve entries based on their creation date within specified date ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->