### PR TITLE
[ODS-65] 다이어리 관련 버그 수정 

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/domain/diary/entity/Diary.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/entity/Diary.java
@@ -100,4 +100,8 @@ public class Diary extends BaseTimeEntity {
   public void addDiaryImage(DiaryImage diaryImage) {
     this.images.add(diaryImage);
   }
+
+  public void updateIsAllGoalsCompleted(Boolean isChecked) {
+    this.isAllGoalsCompleted = isChecked;
+  }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/entity/Diary.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/entity/Diary.java
@@ -55,13 +55,9 @@ public class Diary extends BaseTimeEntity {
   @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<DiaryGoal> diaryGoals = new ArrayList<>();
 
-  ;
-
   @Builder.Default
   @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
   private List<DiaryImage> images = new ArrayList<>();
-
-  ;
 
   @Builder.Default
   @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
@@ -84,6 +80,7 @@ public class Diary extends BaseTimeEntity {
     this.feeling = request.getFeeling();
     this.content = request.getContent();
     this.isPublic = request.getIsPublic();
+    this.completedDate = request.getAchievedDate();
     this.challenge = challenge;
     this.diaryGoals.clear();
     this.diaryGoals.addAll(diaryGoals);

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
@@ -67,6 +67,7 @@ public class DiaryService {
     Optional<Participant> participant =
         participantRepository.findByMemberIdAndChallengeId(memberId, challenge.getId());
 
+    Boolean isCheckedAll = false;
     Diary diary =
         Diary.builder()
             .member(member)
@@ -76,6 +77,7 @@ public class DiaryService {
             .content(request.getContent())
             .feeling(request.getFeeling())
             .isPublic(request.getIsPublic())
+            .isAllGoalsCompleted(isCheckedAll)
             .diaryGoals(new ArrayList<>())
             .likes(new ArrayList<>())
             .build();
@@ -95,6 +97,17 @@ public class DiaryService {
     List<DiaryGoal> diaryGoals = new ArrayList<>();
     List<Long> achievedGoalIds =
         request.getAchievedGoalIds() != null ? request.getAchievedGoalIds() : new ArrayList<>();
+
+    Set<Long> achievedGoalIdSet =
+        new HashSet<>(
+            request.getAchievedGoalIds() != null
+                ? request.getAchievedGoalIds()
+                : new ArrayList<>());
+
+    boolean isAllGoalsCompleted =
+        challengeGoals.stream().allMatch(goal -> achievedGoalIdSet.contains(goal.getId()));
+
+    newDiary.updateIsAllGoalsCompleted(isAllGoalsCompleted);
 
     for (ChallengeGoal challengeGoal : challengeGoals) {
       boolean isCompleted = achievedGoalIds.contains(challengeGoal.getId());

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
@@ -27,6 +27,7 @@ import com.odos.odos_server_v2.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -173,6 +174,25 @@ public class DiaryService {
     List<DiaryGoal> diaryGoals = new ArrayList<>();
     List<Long> achievedGoalIds =
         request.getAchievedGoalIds() != null ? request.getAchievedGoalIds() : new ArrayList<>();
+
+    Set<Long> achievedGoalIdSet =
+        new HashSet<>(
+            request.getAchievedGoalIds() != null
+                ? request.getAchievedGoalIds()
+                : new ArrayList<>());
+
+    boolean isAllGoalsCompleted =
+        challengeGoals.stream().allMatch(goal -> achievedGoalIdSet.contains(goal.getId()));
+    diary.updateIsAllGoalsCompleted(isAllGoalsCompleted);
+
+    Set<Long> challengeGoalIdSet =
+        challengeGoals.stream().map(ChallengeGoal::getId).collect(Collectors.toSet());
+
+    for (Long id : achievedGoalIds) {
+      if (!challengeGoalIdSet.contains(id)) {
+        throw new CustomException(ErrorCode.DIARY_NOT_CREATED);
+      }
+    }
 
     for (ChallengeGoal challengeGoal : challengeGoals) {
       boolean isCompleted = achievedGoalIds.contains(challengeGoal.getId());

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
@@ -67,8 +67,10 @@ public class DiaryService {
     ChallengeSummaryResponse challengeSummary =
         challengeService.toChallengeSummary(challenge, memberId);
 
-    Optional<Participant> participant =
-        participantRepository.findByMemberIdAndChallengeId(memberId, challenge.getId());
+    Participant participant =
+        participantRepository
+            .findByMemberIdAndChallengeId(memberId, challenge.getId())
+            .orElseThrow(() -> new CustomException(ErrorCode.PARTICIPANT_NOT_FOUND));
 
     Boolean isCheckedAll = false;
     Diary diary =
@@ -93,7 +95,7 @@ public class DiaryService {
           challengeGoalRepository.getFixedGoals(
               challenge.getHostMember().getId(), challenge.getId());
     } else {
-      challengeGoals = Objects.requireNonNull(participant.get()).getChallengeGoals();
+      challengeGoals = participant.getChallengeGoals();
     }
     List<DiaryGoal> diaryGoals = new ArrayList<>();
     List<Long> achievedGoalIds =
@@ -147,6 +149,11 @@ public class DiaryService {
         diaryRepository
             .findById(diaryId)
             .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
+
+    if (!diary.getMember().getId().equals(memberId)) {
+      throw new CustomException(ErrorCode.DIARY_NOT_ACCESS);
+    }
+
     Challenge challenge =
         challengeRepository
             .findById(request.getChallengeId())
@@ -158,9 +165,6 @@ public class DiaryService {
         participantRepository
             .findByMemberIdAndChallengeId(memberId, challenge.getId())
             .orElseThrow(() -> new CustomException(ErrorCode.PARTICIPANT_NOT_FOUND));
-    if (participant == null) {
-      throw new CustomException(ErrorCode.PARTICIPANT_NOT_FOUND);
-    }
 
     List<ChallengeGoal> challengeGoals;
     if (challenge.getType().equals(ChallengeType.FIXED)) {
@@ -168,7 +172,7 @@ public class DiaryService {
           challengeGoalRepository.getFixedGoals(
               challenge.getHostMember().getId(), challenge.getId());
     } else {
-      challengeGoals = Objects.requireNonNull(participant).getChallengeGoals();
+      challengeGoals = participant.getChallengeGoals();
     }
 
     List<DiaryGoal> diaryGoals = new ArrayList<>();

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
@@ -83,9 +83,7 @@ public class DiaryService {
             .build();
     Diary newDiary = diaryRepository.save(diary);
 
-    // 챌린지 목표를 기반으로 다이어리 목표달성 생성 및 저장
-    // 이슈발생 후 수정
-    // 챌린지 타입별 챌린지목표 ID 맞춰서 체크하도록
+    // 챌린지 타입별 목표를 기반으로 다이어리 목표달성 생성 및 저장
     List<ChallengeGoal> challengeGoals;
     if (challenge.getType().equals(ChallengeType.FIXED)) {
       challengeGoals =
@@ -106,14 +104,22 @@ public class DiaryService {
 
     boolean isAllGoalsCompleted =
         challengeGoals.stream().allMatch(goal -> achievedGoalIdSet.contains(goal.getId()));
-
     newDiary.updateIsAllGoalsCompleted(isAllGoalsCompleted);
+
+    Set<Long> challengeGoalIdSet =
+        challengeGoals.stream().map(ChallengeGoal::getId).collect(Collectors.toSet());
+
+    for (Long id : achievedGoalIds) {
+      if (!challengeGoalIdSet.contains(id)) {
+        throw new CustomException(ErrorCode.DIARY_NOT_CREATED);
+      }
+    }
 
     for (ChallengeGoal challengeGoal : challengeGoals) {
       boolean isCompleted = achievedGoalIds.contains(challengeGoal.getId());
       DiaryGoal diaryGoal =
           DiaryGoal.builder()
-              .diary(newDiary) // newDiary 이미 저장된 다이어리로 변경
+              .diary(newDiary)
               .challengeGoal(challengeGoal)
               .isCompleted(isCompleted)
               .build();


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, (#이슈번호, ...)
#97 

## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- isAllGoalsCompleted 처리 
- 일지 생성시, 요청한 목표id가 챌린지목표id리스트에 포함되어야만 제대로 생성되도록 수정 

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- 요청사항


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diary entries now explicitly record whether all challenge goals are completed and persist the diary completion date.
  * New public method to update the "all goals completed" flag.

* **Bug Fixes**
  * Validates submitted achieved-goal IDs against the challenge to prevent invalid diary creation/update.
  * Ensures diary completion status is consistently computed and stored.
  * Prevents unauthorized updates by enforcing ownership checks on diary updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->