### PR TITLE
[ODS-147] 비공개 일지 조회 범위 수정 (같은 챌린저도 조회가능하도록)

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/domain/challenge/repository/ParticipantRepository.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/challenge/repository/ParticipantRepository.java
@@ -19,4 +19,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
   Optional<Participant> findByMemberIdAndChallengeId(Long memberId, Long challengeId);
 
   boolean existsByChallengeIdAndMemberId(Long challengeId, Long memberId);
+
+  boolean existsByChallengeIdAndMemberIdAndStatus(
+      Long challengeId, Long memberId, ParticipantStatus status);
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/repository/DiaryRepository.java
@@ -55,4 +55,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
   Page<Diary> findDiariesByChallengeIdAndIsPublic(
       Long challengeId, Boolean isPublic, Pageable pageable);
+
+  // 같은 챌린지의 참여자이면 비공개일지까지 조회되도록
+  Page<Diary> findAllByChallengeId(Long challengeId, Pageable pageable);
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
@@ -4,6 +4,7 @@ import com.odos.odos_server_v2.domain.challenge.dto.ChallengeSummaryResponse;
 import com.odos.odos_server_v2.domain.challenge.entity.Challenge;
 import com.odos.odos_server_v2.domain.challenge.entity.ChallengeGoal;
 import com.odos.odos_server_v2.domain.challenge.entity.Enum.ChallengeType;
+import com.odos.odos_server_v2.domain.challenge.entity.Enum.ParticipantStatus;
 import com.odos.odos_server_v2.domain.challenge.entity.Participant;
 import com.odos.odos_server_v2.domain.challenge.repository.ChallengeGoalRepository;
 import com.odos.odos_server_v2.domain.challenge.repository.ChallengeRepository;
@@ -467,9 +468,17 @@ public class DiaryService {
             .findById(challengeId)
             .orElseThrow(() -> new CustomException(ErrorCode.CHALLENGE_NOT_FOUND));
     ChallengeSummaryResponse summary = challengeService.toChallengeSummary(challenge, memberId);
+    Page<Diary> diaries = null;
+    if ((participantRepository.existsByChallengeIdAndMemberIdAndStatus(
+            challengeId, memberId, ParticipantStatus.PARTICIPANT)
+        || (participantRepository.existsByChallengeIdAndMemberIdAndStatus(
+            challengeId, memberId, ParticipantStatus.HOST)))) {
+      diaries = diaryRepository.findAllByChallengeId(challengeId, pageable);
+    } else {
+      diaries =
+          diaryRepository.findDiariesByChallengeIdAndIsPublic(challengeId, Boolean.TRUE, pageable);
+    }
 
-    Page<Diary> diaries =
-        diaryRepository.findDiariesByChallengeIdAndIsPublic(challengeId, Boolean.TRUE, pageable);
     Page<DiaryResponse> result =
         diaries.map(
             diary ->


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, (#이슈번호, ...)
#151 

## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- 작업내용1
- 작업내용2

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- isPublic 변수명 변경은 마지막에 처리하도록 하겠습니다! 
- 현재 브랜치에서는 적용 안했습니다. 


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced diary visibility: Challenge participants and hosts can now access all diaries from their challenge, including private ones.
  * Non-participating users continue to see only publicly shared diaries from challenges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->