### PR TITLE
[Feature] 회원 탈퇴 테스트용 API 개발

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/domain/member/controller/MemberController.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/controller/MemberController.java
@@ -536,52 +536,54 @@ public class MemberController {
     return ApiResponse.success(Message.MEMBER_DELETE);
   }
 
-    @Operation(summary = "회원 탈퇴", description = "로그인한 회원의 탈퇴를 요청한다. 테스트용으로 요청 시 바로 챌린지 권한이 위임되고 유저가 삭제된다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "회원 탈퇴 요청 성공",
-                    content =
-                    @Content(
-                            mediaType = "application/json",
-                            examples =
-                            @ExampleObject(
-                                    value =
-                                            """
+  @Operation(
+      summary = "회원 탈퇴",
+      description = "로그인한 회원의 탈퇴를 요청한다. 테스트용으로 요청 시 바로 챌린지 권한이 위임되고 유저가 삭제된다.")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "회원 탈퇴 요청 성공",
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
                                             {
                                               "message": "회원 탈퇴가 완료되었습니다."
                                             }
                                             """))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401",
-                    description = "인증되지 않은 접근",
-                    content =
-                    @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples =
-                            @ExampleObject(
-                                    value =
-                                            """
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "401",
+        description = "인증되지 않은 접근",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
                                             { "code": "AUTH-001", "message": "인증되지 않은 접근입니다." }
                                             """))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "회원을 찾을 수 없음",
-                    content =
-                    @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples =
-                            @ExampleObject(
-                                    value =
-                                            """
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "404",
+        description = "회원을 찾을 수 없음",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
                                             { "code": "USER-003", "message": "회원을 찾을 수 없습니다." }
                                             """)))
-    })
+  })
   @DeleteMapping("/test")
-    public ApiResponse<Void> deleteMemberTest() {
-      memberDeleteService.requestWithdrawTest();
-      return ApiResponse.success(Message.MEMBER_DELETE);
+  public ApiResponse<Void> deleteMemberTest() {
+    memberDeleteService.requestWithdrawTest();
+    return ApiResponse.success(Message.MEMBER_DELETE);
   }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/member/controller/MemberController.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/controller/MemberController.java
@@ -1,5 +1,11 @@
 package com.odos.odos_server_v2.domain.member.controller;
 
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
 import com.odos.odos_server_v2.domain.member.CurrentUserContext;
 import com.odos.odos_server_v2.domain.member.dto.MyPageDto;
 import com.odos.odos_server_v2.domain.member.dto.NicknameRequest;
@@ -18,10 +24,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "회원", description = "회원 API")
 @RestController
@@ -548,10 +550,10 @@ public class MemberController {
                     @ExampleObject(
                         value =
                             """
-                                            {
-                                              "message": "회원 탈퇴가 완료되었습니다."
-                                            }
-                                            """))),
+                            {
+                            "message": "회원 탈퇴가 완료되었습니다."
+                            }
+                            """))),
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
         responseCode = "401",
         description = "인증되지 않은 접근",
@@ -563,8 +565,8 @@ public class MemberController {
                     @ExampleObject(
                         value =
                             """
-                                            { "code": "AUTH-001", "message": "인증되지 않은 접근입니다." }
-                                            """))),
+                            { "code": "AUTH-001", "message": "인증되지 않은 접근입니다." }
+                            """))),
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
         responseCode = "404",
         description = "회원을 찾을 수 없음",
@@ -576,8 +578,8 @@ public class MemberController {
                     @ExampleObject(
                         value =
                             """
-                                            { "code": "USER-003", "message": "회원을 찾을 수 없습니다." }
-                                            """)))
+                            { "code": "USER-003", "message": "회원을 찾을 수 없습니다." }
+                            """)))
   })
   @DeleteMapping("/test")
   public ApiResponse<Void> deleteMemberTest() {

--- a/src/main/java/com/odos/odos_server_v2/domain/member/controller/MemberController.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/controller/MemberController.java
@@ -1,11 +1,5 @@
 package com.odos.odos_server_v2.domain.member.controller;
 
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.*;
-
 import com.odos.odos_server_v2.domain.member.CurrentUserContext;
 import com.odos.odos_server_v2.domain.member.dto.MyPageDto;
 import com.odos.odos_server_v2.domain.member.dto.NicknameRequest;
@@ -24,6 +18,10 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "회원", description = "회원 API")
 @RestController

--- a/src/main/java/com/odos/odos_server_v2/domain/member/controller/MemberController.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/controller/MemberController.java
@@ -1,5 +1,11 @@
 package com.odos.odos_server_v2.domain.member.controller;
 
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
 import com.odos.odos_server_v2.domain.member.CurrentUserContext;
 import com.odos.odos_server_v2.domain.member.dto.MyPageDto;
 import com.odos.odos_server_v2.domain.member.dto.NicknameRequest;
@@ -18,10 +24,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "회원", description = "회원 API")
 @RestController
@@ -532,5 +534,54 @@ public class MemberController {
   public ApiResponse<Void> deleteMember() {
     memberDeleteService.requestWithdraw();
     return ApiResponse.success(Message.MEMBER_DELETE);
+  }
+
+    @Operation(summary = "회원 탈퇴", description = "로그인한 회원의 탈퇴를 요청한다. 테스트용으로 요청 시 바로 챌린지 권한이 위임되고 유저가 삭제된다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "회원 탈퇴 요청 성공",
+                    content =
+                    @Content(
+                            mediaType = "application/json",
+                            examples =
+                            @ExampleObject(
+                                    value =
+                                            """
+                                            {
+                                              "message": "회원 탈퇴가 완료되었습니다."
+                                            }
+                                            """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 접근",
+                    content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples =
+                            @ExampleObject(
+                                    value =
+                                            """
+                                            { "code": "AUTH-001", "message": "인증되지 않은 접근입니다." }
+                                            """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회원을 찾을 수 없음",
+                    content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples =
+                            @ExampleObject(
+                                    value =
+                                            """
+                                            { "code": "USER-003", "message": "회원을 찾을 수 없습니다." }
+                                            """)))
+    })
+  @DeleteMapping("/test")
+    public ApiResponse<Void> deleteMemberTest() {
+      memberDeleteService.requestWithdrawTest();
+      return ApiResponse.success(Message.MEMBER_DELETE);
   }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
@@ -1,17 +1,14 @@
 package com.odos.odos_server_v2.domain.member.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.odos.odos_server_v2.domain.challenge.service.ChallengeService;
 import com.odos.odos_server_v2.domain.member.CurrentUserContext;
 import com.odos.odos_server_v2.domain.member.entity.Member;
 import com.odos.odos_server_v2.domain.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
@@ -1,14 +1,17 @@
 package com.odos.odos_server_v2.domain.member.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.odos.odos_server_v2.domain.challenge.service.ChallengeService;
 import com.odos.odos_server_v2.domain.member.CurrentUserContext;
 import com.odos.odos_server_v2.domain.member.entity.Member;
 import com.odos.odos_server_v2.domain.member.repository.MemberRepository;
-import java.time.LocalDateTime;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -50,5 +53,22 @@ public class MemberDeleteService {
     for (Member member : targets) {
       hardDelete(member);
     }
+  }
+
+  @Transactional
+  public void requestWithdrawTest() {
+    Long memberId = CurrentUserContext.getCurrentMemberId();
+    Member member =
+            memberRepository
+                    .findById(memberId)
+                    .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+    // 탈퇴 상태 변경
+    member.withdraw();
+
+    // 주최 중인 챌린지 host 위임
+    challengeService.withdrawMemberLeaveChallengeHost(member.getId());
+
+    hardDelete(member);
   }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
@@ -59,9 +59,9 @@ public class MemberDeleteService {
   public void requestWithdrawTest() {
     Long memberId = CurrentUserContext.getCurrentMemberId();
     Member member =
-            memberRepository
-                    .findById(memberId)
-                    .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
 
     // 탈퇴 상태 변경
     member.withdraw();


### PR DESCRIPTION
## 연관된 이슈
> #161 


## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- dev 환경에서 회원이 바로 삭제되도록 하는 API 개발하였습니다.

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- 요청사항


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new test-only account deletion endpoint that immediately removes a member's account when invoked.

* **Tests**
  * Added supporting service logic and test flows for immediate deletion and withdrawal scenarios.

* **Behavior**
  * The existing standard account withdrawal endpoint and its behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->