### PR TITLE
[ODS-168] feat: Feat: 멤버 탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/domain/member/entity/Enum/MemberStatus.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/entity/Enum/MemberStatus.java
@@ -2,5 +2,6 @@ package com.odos.odos_server_v2.domain.member.entity.Enum;
 
 public enum MemberStatus {
   ACTIVE,
-  WITHDRAWN
+  WITHDRAWN,
+  DELETED
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/member/entity/Member.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/entity/Member.java
@@ -164,4 +164,9 @@ public class Member {
 
     this.refreshToken = null;
   }
+
+  public void restore() {
+    this.status = MemberStatus.ACTIVE;
+    this.deletedAt = null;
+  }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/member/entity/Member.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/entity/Member.java
@@ -152,4 +152,16 @@ public class Member {
     this.status = MemberStatus.WITHDRAWN;
     this.deletedAt = LocalDateTime.now();
   }
+
+  public void softDelete() {
+    this.status = MemberStatus.DELETED;
+
+    String dummySuffix = this.id + "_" + System.currentTimeMillis();
+
+    this.email = "deleted_" + dummySuffix + "@deleted.local";
+    this.socialId = "deleted_" + dummySuffix;
+    this.nickname = "탈퇴한 사용자";
+
+    this.refreshToken = null;
+  }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/repository/MemberRepository.java
@@ -1,13 +1,15 @@
 package com.odos.odos_server_v2.domain.member.repository;
 
-import com.odos.odos_server_v2.domain.member.entity.Enum.SignupRoute;
-import com.odos.odos_server_v2.domain.member.entity.Member;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import com.odos.odos_server_v2.domain.member.entity.Enum.SignupRoute;
+import com.odos.odos_server_v2.domain.member.entity.Member;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -15,7 +17,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByRefreshToken(String refreshToken);
 
-  @Query("SELECT m FROM Member m WHERE m.deletedAt IS NOT NULL AND m.deletedAt < :threshold")
+  @Query(
+      "SELECT m FROM Member m WHERE m.status='WITHDRAWN' and m.deletedAt IS NOT NULL AND m.deletedAt < :threshold")
   List<Member> findDeletableMembers(LocalDateTime threshold);
 
   boolean existsByNickname(String nickname);

--- a/src/main/java/com/odos/odos_server_v2/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/repository/MemberRepository.java
@@ -1,15 +1,13 @@
 package com.odos.odos_server_v2.domain.member.repository;
 
+import com.odos.odos_server_v2.domain.member.entity.Enum.SignupRoute;
+import com.odos.odos_server_v2.domain.member.entity.Member;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import com.odos.odos_server_v2.domain.member.entity.Enum.SignupRoute;
-import com.odos.odos_server_v2.domain.member.entity.Member;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {

--- a/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
@@ -1,17 +1,15 @@
 package com.odos.odos_server_v2.domain.member.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.odos.odos_server_v2.domain.challenge.service.ChallengeService;
 import com.odos.odos_server_v2.domain.member.CurrentUserContext;
+import com.odos.odos_server_v2.domain.member.entity.Enum.MemberStatus;
 import com.odos.odos_server_v2.domain.member.entity.Member;
 import com.odos.odos_server_v2.domain.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -61,6 +59,20 @@ public class MemberDeleteService {
 
     for (Member member : targets) {
       member.softDelete();
+    }
+  }
+
+  @Transactional
+  public void restoreMember() {
+    Long memberId = CurrentUserContext.getCurrentMemberId();
+    Member member =
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+    if (member.getStatus() == MemberStatus.WITHDRAWN
+        && member.getDeletedAt().isAfter(LocalDateTime.now().minusDays(7))) {
+      member.restore();
+      challengeService.rejoinMemberRestoreIndividualChallenge(memberId);
     }
   }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
@@ -1,5 +1,7 @@
 package com.odos.odos_server_v2.domain.member.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
@@ -49,5 +51,16 @@ public class MemberDeleteService {
 
     // 주최 중인 챌린지 host 위임
     challengeService.withdrawMemberLeaveChallengeHost(member.getId());
+  }
+
+  @Transactional
+  public void processDeletion() {
+    LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+
+    List<Member> targets = memberRepository.findDeletableMembers(threshold);
+
+    for (Member member : targets) {
+      member.softDelete();
+    }
   }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/member/service/MemberDeleteService.java
@@ -1,14 +1,15 @@
 package com.odos.odos_server_v2.domain.member.service;
 
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.odos.odos_server_v2.domain.challenge.service.ChallengeService;
 import com.odos.odos_server_v2.domain.member.CurrentUserContext;
 import com.odos.odos_server_v2.domain.member.entity.Member;
 import com.odos.odos_server_v2.domain.member.repository.MemberRepository;
-import java.time.LocalDateTime;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,26 +31,9 @@ public class MemberDeleteService {
     member.withdraw();
 
     // 주최 중인 챌린지 host 위임
-    challengeService.withdrawMemberLeaveChallengeHost(member.getId());
-  }
+    challengeService.withdrawMemberLeaveChallenge(member.getId());
 
-  /** 2. 실제 삭제 (Hard Delete) - 탈퇴 후 7일 지난 회원 */
-  @Transactional
-  public void hardDelete(Member member) {
-    memberRepository.delete(member);
-  }
-
-  /** 3. 스케줄러에서 실행 */
-  @Transactional
-  public void processDeletion() {
-
-    LocalDateTime threshold = LocalDateTime.now().minusDays(7);
-
-    List<Member> targets = memberRepository.findDeletableMembers(threshold);
-
-    for (Member member : targets) {
-      hardDelete(member);
-    }
+    // 일지 처리
   }
 
   @Transactional
@@ -65,7 +49,5 @@ public class MemberDeleteService {
 
     // 주최 중인 챌린지 host 위임
     challengeService.withdrawMemberLeaveChallengeHost(member.getId());
-
-    hardDelete(member);
   }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.odos.odos_server_v2.domain.member.entity.Enum.SignupRoute;
 import com.odos.odos_server_v2.domain.member.entity.Member;
 import com.odos.odos_server_v2.domain.member.repository.MemberRepository;
+import com.odos.odos_server_v2.domain.member.service.MemberDeleteService;
 import com.odos.odos_server_v2.domain.security.jwt.JwtTokenProvider;
 import com.odos.odos_server_v2.domain.security.jwt.MemberPrincipal;
 import com.odos.odos_server_v2.domain.security.oauth2.OAuth2LoginResponse;
@@ -28,6 +29,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
   private final JwtTokenProvider jwtTokenProvider;
   private final ObjectMapper objectMapper;
   private final MemberRepository memberRepository;
+  private final MemberDeleteService memberDeleteService;
 
   @Override
   public void onAuthenticationSuccess(
@@ -73,5 +75,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     ApiResponse<OAuth2LoginResponse> apiResponse = ApiResponse.success(LOGIN_SUCCESS, dto);
     response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
     // log.debug("OAuth2 login success - {} (profileComplete={})", email, isProfileComplete);
+
+    // 탈퇴 처리 이후 7일 이전 로그인 시
+    memberDeleteService.restoreMember();
   }
 }


### PR DESCRIPTION
## 연관된 이슈
> #170 


## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- 모든 데이터 소프트딜리트 처리
- 멤버 탈퇴 7일 이후에는 닉네임, 이메일+소셜로그인 제공자 값을 더미 값으로 변경
- 7일 내 재가입 시 개인 챌린지 복구

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- 일지 소프트딜리트 로직이 아직 추가되지 않았습니다


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Members can now delete their accounts with automatic anonymization of personal data
* Deleted accounts can be restored within a 7-day grace period if the user decides to recover them
* User accounts are automatically restored when logging back in through social authentication if they were deleted and are now eligible for recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->