### PR TITLE
[ODS-175] 일지 soft delete로 처리

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/challenge/service/ChallengeService.java
@@ -334,7 +334,7 @@ public class ChallengeService {
     for (Challenge c : challenges) {
       if (c.getDeletedAt().isAfter(LocalDateTime.now().minusDays(7))) {
         c.restore();
-        // TODO: 일지 복구 처리
+        restoreMemberDiariesInChallenge(c.getId(), memberId);
       }
     }
   }
@@ -349,7 +349,7 @@ public class ChallengeService {
     if (challenge.getParticipationType().equals(ParticipationType.INDIVIDUAL)) {
       // 개인 챌린지
       challenge.softDelete();
-      // TODO: 일지 삭제 처리
+      diaryRepository.softDeleteByChallengeIdAndMemberId(challengeId, memberId);
     } else {
       // 단체 챌린지
       // 호스트라면 호스트를 넘김
@@ -361,7 +361,7 @@ public class ChallengeService {
                 .findByMemberIdAndChallengeId(memberId, challengeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PARTICIPANT_NOT_FOUND));
         participant.setStatus(ParticipantStatus.LEAVE);
-        // TODO: 일지 삭제 처리
+        diaryRepository.softDeleteByChallengeIdAndMemberId(challengeId, memberId);
       }
     }
   }
@@ -388,6 +388,7 @@ public class ChallengeService {
     if (candidates.isEmpty()) {
       challenge.softDelete();
       currentHost.setStatus(ParticipantStatus.LEAVE);
+      softDeleteMemberDiariesInChallenge(challengeId, memberId);
       return;
     }
 
@@ -418,6 +419,7 @@ public class ChallengeService {
     participantRepository.save(nextHost);
     participantRepository.save(currentHost);
     challengeRepository.save(challenge);
+    softDeleteMemberDiariesInChallenge(challengeId, memberId);
   }
 
   private long countDiaryGoals(Long participantId) {
@@ -696,5 +698,13 @@ public class ChallengeService {
     List<Diary> diaries =
         diaryRepository.findDiariesByDateRange(twoDaysAgo, today, challengeId, currentMemberId);
     return DiaryStreakResponse.checkStreak(diaries);
+  }
+
+  private void softDeleteMemberDiariesInChallenge(Long challengeId, Long memberId) {
+    diaryRepository.softDeleteByChallengeIdAndMemberId(challengeId, memberId);
+  }
+
+  private void restoreMemberDiariesInChallenge(Long challengeId, Long memberId) {
+    diaryRepository.restoreByChallengeIdAndMemberId(challengeId, memberId);
   }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/comment/service/CommentService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/comment/service/CommentService.java
@@ -37,7 +37,7 @@ public class CommentService {
             .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     Diary diary =
         diaryRepository
-            .findById(diaryId)
+            .findByIdAndIsDeletedFalse(diaryId)
             .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
 
     Comment comment =

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/entity/Diary.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/entity/Diary.java
@@ -101,4 +101,12 @@ public class Diary extends BaseTimeEntity {
   public void updateIsAllGoalsCompleted(Boolean isChecked) {
     this.isAllGoalsCompleted = isChecked;
   }
+
+  public void softDelete() {
+    this.isDeleted = true;
+  }
+
+  public void restore() {
+    this.isDeleted = false;
+  }
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/repository/DiaryRepository.java
@@ -3,18 +3,22 @@ package com.odos.odos_server_v2.domain.diary.repository;
 import com.odos.odos_server_v2.domain.diary.entity.Diary;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-  List<Diary> findDiariesByIsPublic(Boolean isPublic);
+  Optional<Diary> findByIdAndIsDeletedFalse(Long id); // 기존 공개다이어리만 조회에서 softDelete 적용 위해 이거 추가
 
-  Page<Diary> findDiariesByMember_Id(Long memberId, Pageable pageable);
+  List<Diary> findDiariesByIsPublicAndIsDeletedFalse(Boolean isPublic);
+
+  Page<Diary> findDiariesByMember_IdAndIsDeletedFalse(Long memberId, Pageable pageable);
 
   long countByChallengeIdAndIsAllGoalsCompletedTrue(Long challengeId);
 
@@ -23,14 +27,14 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
       """
       select d
       from Diary d
-      where d.isPublic = true
+      where d.isPublic = true and d.isDeleted=false
         and (:cursorId is null or d.id < :cursorId)
       order by d.id desc
     """)
   List<Diary> findPublicPage(@Param("cursorId") Long cursorId, Pageable pageable);
 
   @Query(
-      "select d from Diary d where d.completedDate between :startDate and :endDate and d.member.id=:writer and d.challenge.id=:id")
+      "select d from Diary d where d.completedDate between :startDate and :endDate and d.member.id=:writer and d.challenge.id=:id and d.isDeleted=false")
   List<Diary> findDiariesByDateRange(
       @Param("startDate") LocalDate startDate,
       @Param("endDate") LocalDate endDate,
@@ -41,7 +45,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
       """
         select d
         from Diary d
-        where d.isPublic = true and d.member.id = :memberId
+        where d.isPublic = true and d.member.id = :memberId and d.isDeleted=false
         order by d.createdAt desc, d.id desc
         """)
   List<Diary> findOthersPublicDiaries(@Param("memberId") Long memberId);
@@ -55,14 +59,14 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
             """)
   Page<Diary> findOthersPublicDiariesByOffset(@Param("memberId") Long memberId, Pageable pageable);
 
-  Page<Diary> findDiariesByChallengeIdAndIsPublic(
+  Page<Diary> findDiariesByChallengeIdAndIsPublicAndIsDeletedFalse(
       Long challengeId, Boolean isPublic, Pageable pageable);
 
   // 같은 챌린지의 참여자이면 비공개일지까지 조회되도록
-  Page<Diary> findAllByChallengeId(Long challengeId, Pageable pageable);
+  Page<Diary> findAllByChallengeIdAndIsDeletedFalse(Long challengeId, Pageable pageable);
 
   // 특정 날짜의 일지 (완료날짜 기준)
-  @Query("select d from Diary d where d.completedDate=:completedDate")
+  @Query("select d from Diary d where d.completedDate=:completedDate and d.isDeleted=false")
   Page<Diary> findDiariesWithCompletedDate(
       @Param("completedDate") LocalDate startDate, Pageable pageable);
 
@@ -70,12 +74,13 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
       """
 select d
 from Diary d
-where (:createdAt is null or cast(d.createdAt as LocalDate) = :createdAt)
+where (:createdAt is null or cast(d.createdAt as LocalDate) = :createdAt) and d.isDeleted=false
 """)
   Page<Diary> findDiariesWithCreatedDate(
       @Param("createdAt") LocalDate createdAt, Pageable pageable);
 
-  @Query("select d from Diary d where d.completedDate between :startDate and :endDate")
+  @Query(
+      "select d from Diary d where d.completedDate between :startDate and :endDate and d.isDeleted=false")
   Page<Diary> findDiariesByDateRangeWithCompletedDate(
       @Param("startDate") LocalDate startDate,
       @Param("endDate") LocalDate endDate,
@@ -86,8 +91,32 @@ where (:createdAt is null or cast(d.createdAt as LocalDate) = :createdAt)
 select d
 from Diary d
 where (:startDate is null or cast(d.createdAt as LocalDate) >= :startDate)
-  and (:endDate is null or cast(d.createdAt as LocalDate) <= :endDate)
+  and (:endDate is null or cast(d.createdAt as LocalDate) <= :endDate) and d.isDeleted=false
 """)
   Page<Diary> findDiariesByDateRangeWithCreatedDate(
       @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate, Pageable page);
+
+  @Modifying
+  @Query(
+      """
+            update Diary d
+            set d.isDeleted = true
+            where d.challenge.id = :challengeId
+              and d.member.id = :memberId
+              and d.isDeleted = false
+            """)
+  void softDeleteByChallengeIdAndMemberId(
+      @Param("challengeId") Long challengeId, @Param("memberId") Long memberId);
+
+  @Modifying
+  @Query(
+      """
+            update Diary d
+            set d.isDeleted = false
+            where d.challenge.id = :challengeId
+              and d.member.id = :memberId
+              and d.isDeleted = true
+            """)
+  void restoreByChallengeIdAndMemberId(
+      @Param("challengeId") Long challengeId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
@@ -152,7 +152,7 @@ public class DiaryService {
             .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     Diary diary =
         diaryRepository
-            .findById(diaryId)
+            .findByIdAndIsDeletedFalse(diaryId)
             .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
 
     if (!diary.getMember().getId().equals(memberId)) {
@@ -233,7 +233,7 @@ public class DiaryService {
             .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
     Diary diary =
         diaryRepository
-            .findById(diaryId)
+            .findByIdAndIsDeletedFalse(diaryId)
             .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
 
     Long writer = diary.getMember().getId();
@@ -260,7 +260,7 @@ public class DiaryService {
   public List<DiaryResponse> getAllPublicDiaries() {
     Long memberId = CurrentUserContext.getCurrentMemberIdOrNull();
     Member member = (memberId != null) ? memberRepository.findById(memberId).orElse(null) : null;
-    List<Diary> diaries = diaryRepository.findDiariesByIsPublic(Boolean.TRUE);
+    List<Diary> diaries = diaryRepository.findDiariesByIsPublicAndIsDeletedFalse(Boolean.TRUE);
     List<DiaryResponse> diaryResponses = new ArrayList<>();
 
     for (Diary diary : diaries) {
@@ -315,10 +315,12 @@ public class DiaryService {
   }
 
   public Boolean deleteDiary(Long diaryId) {
-    diaryRepository
-        .findById(diaryId)
-        .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
-    diaryRepository.deleteById(diaryId);
+    Diary diary =
+        diaryRepository
+            .findByIdAndIsDeletedFalse(diaryId)
+            .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
+    // diaryRepository.deleteById(diaryId);
+    diary.softDelete();
     return true;
   }
 
@@ -326,7 +328,7 @@ public class DiaryService {
   public Integer addDiaryLike(Long memberId, Long diaryId) {
     Diary diary =
         diaryRepository
-            .findById(diaryId)
+            .findByIdAndIsDeletedFalse(diaryId)
             .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
     Member pressedMember =
         memberRepository
@@ -347,7 +349,7 @@ public class DiaryService {
 
   public Integer cancelDiaryLike(Long memberId, Long diaryId) {
     diaryRepository
-        .findById(diaryId)
+        .findByIdAndIsDeletedFalse(diaryId)
         .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
     memberRepository
         .findById(memberId)
@@ -372,7 +374,7 @@ public class DiaryService {
               ? memberRepository.findById(currentMemberId).orElse(null)
               : null;
 
-      List<Diary> diaries = diaryRepository.findDiariesByIsPublic(Boolean.TRUE);
+      List<Diary> diaries = diaryRepository.findDiariesByIsPublicAndIsDeletedFalse(Boolean.TRUE);
       if (diaries.isEmpty()) {
         return Collections.emptyList();
       }
@@ -402,7 +404,7 @@ public class DiaryService {
             .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     Diary diary =
         diaryRepository
-            .findById(request.getDiaryId())
+            .findByIdAndIsDeletedFalse(request.getDiaryId())
             .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
     DiaryReport diaryReport =
         DiaryReport.builder()
@@ -424,7 +426,9 @@ public class DiaryService {
         memberRepository
             .findById(memberId)
             .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-    Page<Diary> diaries = diaryRepository.findDiariesByMember_Id(memberId, pageable);
+    Page<Diary> diaries =
+        diaryRepository.findDiariesByMember_IdAndIsDeletedFalse(
+            memberId, pageable); // TODO : 마이페이지에서도 softDelete된거 안보이게? 적용하긴 하였으나
 
     Page<DiaryResponse> diaryResponsePage =
         diaries.map(
@@ -458,7 +462,7 @@ public class DiaryService {
     Long memberId = CurrentUserContext.getCurrentMemberId();
     Diary diary =
         diaryRepository
-            .findById(diaryId)
+            .findByIdAndIsDeletedFalse(diaryId)
             .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
     List<String> fileList = imageService.uploadFiles(files);
     List<DiaryImage> diaryImages = new ArrayList<>();
@@ -486,10 +490,11 @@ public class DiaryService {
             challengeId, memberId, ParticipantStatus.PARTICIPANT)
         || (participantRepository.existsByChallengeIdAndMemberIdAndStatus(
             challengeId, memberId, ParticipantStatus.HOST)))) {
-      diaries = diaryRepository.findAllByChallengeId(challengeId, pageable);
+      diaries = diaryRepository.findAllByChallengeIdAndIsDeletedFalse(challengeId, pageable);
     } else {
       diaries =
-          diaryRepository.findDiariesByChallengeIdAndIsPublic(challengeId, Boolean.TRUE, pageable);
+          diaryRepository.findDiariesByChallengeIdAndIsPublicAndIsDeletedFalse(
+              challengeId, Boolean.TRUE, pageable);
     }
 
     Page<DiaryResponse> result =

--- a/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/diary/service/DiaryService.java
@@ -314,6 +314,7 @@ public class DiaryService {
     return new Pagination<>(items, pageInfo);
   }
 
+  @Transactional
   public Boolean deleteDiary(Long diaryId) {
     Diary diary =
         diaryRepository
@@ -321,6 +322,7 @@ public class DiaryService {
             .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
     // diaryRepository.deleteById(diaryId);
     diary.softDelete();
+    diaryRepository.save(diary);
     return true;
   }
 


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, (#이슈번호, ...)
#176 

## 작업 내용
> 해당 PR에서 작업한 내용을 간단히 설명해주세요.
> 엔터 쳐서 계속 작업

- 일지가 삭제될때 db 완전삭제가 아닌 isDeleted=true로 수정되도록 구현 

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
- 요청사항


## 기타 (선택)
> 문제 사항이나 코드조언을 받을 때 pr 날리는 등의 상황 설명 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diaries are now softly deleted when leaving challenges and can be restored if you rejoin.

* **Bug Fixes**
  * Comments can no longer be created on deleted diaries.
  * Deleted diaries are now properly excluded from all diary listings, searches, and challenge feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->