### PR TITLE
feat(notification): implement Notification domain entities and repositories

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/domain/notification/entity/Enum/NotificationType.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/notification/entity/Enum/NotificationType.java
@@ -1,0 +1,17 @@
+package com.odos.odos_server_v2.domain.notification.entity.Enum;
+
+public enum NotificationType {
+  // 친구 관련
+  FRIEND_REQUEST,
+  FRIEND_ACCEPT,
+
+  // 일지 및 커뮤니티
+  FRIEND_DIARY_CREATED,
+  DIARY_COMMENT_CREATED,
+  DIARY_COMMENT_REPLY_CREATED,
+  DIARY_LIKE_MILESTONE, // 좋아요 마일스톤 달성
+
+  // 챌린지 관련
+  CHALLENGE_ACCEPTED,
+  CHALLENGE_REJECTED
+}

--- a/src/main/java/com/odos/odos_server_v2/domain/notification/entity/Notification.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/notification/entity/Notification.java
@@ -1,0 +1,56 @@
+package com.odos.odos_server_v2.domain.notification.entity;
+
+import com.odos.odos_server_v2.domain.notification.entity.Enum.NotificationType;
+import com.odos.odos_server_v2.domain.shared.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notification")
+public class Notification extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "notification_id")
+  private Long id;
+
+  @Column(name = "receiver_id", nullable = false)
+  private Long receiverId; // 알림을 받는 사용자 (Member)
+
+  @Column(name = "sender_id")
+  private Long senderId; // 알림을 발생시킨 사용자 (Member) - 시스템 알림일 경우 null
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "type", nullable = false)
+  private NotificationType type;
+
+  @Column(name = "target_id")
+  private Long targetId; // 관련된 엔티티(일지, 댓글, 챌린지 등)의 ID
+
+  // 좋아요 마일스톤 달성 개수 같은 추가 정보를 담기 위해 확장 가능성을 열어둠 (Optional)
+  @Column(name = "meta_data")
+  private String metaData;
+
+  @Column(name = "is_read", nullable = false)
+  private boolean isRead;
+
+  @Builder
+  public Notification(
+      Long receiverId, Long senderId, NotificationType type, Long targetId, String metaData) {
+    this.receiverId = receiverId;
+    this.senderId = senderId;
+    this.type = type;
+    this.targetId = targetId;
+    this.metaData = metaData;
+    this.isRead = false;
+  }
+
+  public void markAsRead() {
+    this.isRead = true;
+  }
+}

--- a/src/main/java/com/odos/odos_server_v2/domain/notification/entity/NotificationSetting.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/notification/entity/NotificationSetting.java
@@ -1,0 +1,69 @@
+package com.odos.odos_server_v2.domain.notification.entity;
+
+import com.odos.odos_server_v2.domain.shared.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notification_setting")
+public class NotificationSetting extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "notification_setting_id")
+  private Long id;
+
+  // 설정은 회원과 강한 연관관계로 가져가 라이프사이클을 함께 하거나, 아니면 결합도를 낮추기 위해 memberId로 가질 수 있음.
+  // 보통 설정은 회원을 조회할 때 자주 같이 조회되거나 영속성 전이를 활용하기 위해 외래키 관계를 맺습니다.
+  // 하지만 회원 조회 성능 저하를 방지하고 유지보수를 편하게 하기 위해 다른 도메인처럼 단방향 @OneToOne 매핑을 설정하거나 memberId를 사용합니다.
+  // 여기서는 memberId로 결합도를 낮추어 구현합니다.
+  @Column(name = "member_id", nullable = false, unique = true)
+  private Long memberId;
+
+  @Column(name = "friend_notification", nullable = false)
+  private boolean friendNotification; // 친구 카테고리 알림 On/Off
+
+  @Column(name = "diary_notification", nullable = false)
+  private boolean diaryNotification; // 일지 카테고리 알림 On/Off
+
+  @Column(name = "challenge_notification", nullable = false)
+  private boolean challengeNotification; // 챌린지 카테고리 알림 On/Off
+
+  @Builder
+  public NotificationSetting(
+      Long memberId,
+      boolean friendNotification,
+      boolean diaryNotification,
+      boolean challengeNotification) {
+    this.memberId = memberId;
+    this.friendNotification = friendNotification;
+    this.diaryNotification = diaryNotification;
+    this.challengeNotification = challengeNotification;
+  }
+
+  public static NotificationSetting createDefault(Long memberId) {
+    return NotificationSetting.builder()
+        .memberId(memberId)
+        .friendNotification(true)
+        .diaryNotification(true)
+        .challengeNotification(true)
+        .build();
+  }
+
+  public void updateFriendNotification(boolean isEnabled) {
+    this.friendNotification = isEnabled;
+  }
+
+  public void updateDiaryNotification(boolean isEnabled) {
+    this.diaryNotification = isEnabled;
+  }
+
+  public void updateChallengeNotification(boolean isEnabled) {
+    this.challengeNotification = isEnabled;
+  }
+}

--- a/src/main/java/com/odos/odos_server_v2/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,41 @@
+package com.odos.odos_server_v2.domain.notification.repository;
+
+import com.odos.odos_server_v2.domain.notification.entity.Notification;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  // 특정 사용자의 알림을 최신순으로 조회
+  List<Notification> findAllByReceiverIdOrderByCreatedAtDesc(Long receiverId, Pageable pageable);
+
+  // 읽지 않은 알림이 있는지 확인
+  boolean existsByReceiverIdAndIsReadFalse(Long receiverId);
+
+  // 특정 사용자의 전체 알림 개수 조회 (100건 초과 여부 확인용 등)
+  long countByReceiverId(Long receiverId);
+
+  // 오래된 알림을 삭제하기 위한 쿼리 (30일이 지났거나, 특정 개수를 초과한 경우 스케줄러에서 활용)
+  @Modifying
+  @Query("DELETE FROM Notification n WHERE n.createdAt < :thresholdDate")
+  void deleteByCreatedAtBefore(@Param("thresholdDate") LocalDateTime thresholdDate);
+
+  // 100건 초과분 삭제를 위해 삭제할 ID 리스트를 받아와 삭제
+  @Modifying
+  @Query("DELETE FROM Notification n WHERE n.id IN :ids")
+  void deleteAllByIdIn(@Param("ids") List<Long> ids);
+
+  // 삭제 대상 ID 목록을 조회 (Native Query 또는 Pageable을 활용하여 구현 가능)
+  // Spring Data JPA에서 limit 처리를 위해 Pageable을 사용할 수 있습니다.
+  @Query(
+      "SELECT n.id FROM Notification n WHERE n.receiverId = :receiverId ORDER BY n.createdAt ASC")
+  List<Long> findOldestNotificationIdsByReceiverId(
+      @Param("receiverId") Long receiverId, Pageable pageable);
+}

--- a/src/main/java/com/odos/odos_server_v2/domain/notification/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/notification/repository/NotificationSettingRepository.java
@@ -1,0 +1,13 @@
+package com.odos.odos_server_v2.domain.notification.repository;
+
+import com.odos.odos_server_v2.domain.notification.entity.NotificationSetting;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+
+  // 회원 ID로 알림 설정 조회
+  Optional<NotificationSetting> findByMemberId(Long memberId);
+}


### PR DESCRIPTION
Implemented the basic JPA entity and repository design for the Notification domain according to user requirements. The solution features decoupled associations (`Long` target and sender IDs) rather than strict foreign keys, uses an enum for types allowing dynamic API-level message rendering, and cleanly isolates push settings into a separate entity. Also added cleanup queries in preparation for scheduled retention tasks.

---
*PR created automatically by Jules for task [6728362697944143980](https://jules.google.com/task/6728362697944143980) started by @hwnooy*