### PR TITLE
feat: add notification entity and repository

### DIFF
--- a/src/main/java/com/odos/odos_server_v2/domain/notification/entity/Enum/NotificationCategory.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/notification/entity/Enum/NotificationCategory.java
@@ -1,0 +1,7 @@
+package com.odos.odos_server_v2.domain.notification.entity.Enum;
+
+public enum NotificationCategory {
+  FRIEND,
+  DIARY,
+  CHALLENGE
+}

--- a/src/main/java/com/odos/odos_server_v2/domain/notification/entity/Enum/NotificationType.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/notification/entity/Enum/NotificationType.java
@@ -1,0 +1,12 @@
+package com.odos.odos_server_v2.domain.notification.entity.Enum;
+
+public enum NotificationType {
+  FRIEND_REQUEST,
+  FRIEND_ACCEPT,
+  DIARY_CREATED,
+  COMMENT_CREATED,
+  REPLY_CREATED,
+  LIKE_MILESTONE,
+  CHALLENGE_ACCEPTED,
+  CHALLENGE_REJECTED
+}

--- a/src/main/java/com/odos/odos_server_v2/domain/notification/entity/Notification.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/notification/entity/Notification.java
@@ -1,0 +1,54 @@
+package com.odos.odos_server_v2.domain.notification.entity;
+
+import com.odos.odos_server_v2.domain.notification.entity.Enum.NotificationCategory;
+import com.odos.odos_server_v2.domain.notification.entity.Enum.NotificationType;
+import com.odos.odos_server_v2.domain.shared.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "notification")
+public class Notification extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "notification_id")
+  private Long id;
+
+  @Column(nullable = false)
+  private Long receiverId; // Member ID who receives the notification
+
+  @Column
+  private Long senderId; // Member ID who triggered the event (can be null for system notifications)
+
+  @Column private Long targetId; // Reference ID for related domain (e.g., DiaryId, ChallengeId)
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationType type;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationCategory category;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private Boolean isRead = false;
+
+  @Column
+  private Integer milestoneCount; // Only used for LIKE_MILESTONE, represents the number of likes
+
+  public void markAsRead() {
+    this.isRead = true;
+  }
+}

--- a/src/main/java/com/odos/odos_server_v2/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/odos/odos_server_v2/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,26 @@
+package com.odos.odos_server_v2.domain.notification.repository;
+
+import com.odos.odos_server_v2.domain.notification.entity.Notification;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  List<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId);
+
+  long countByReceiverId(Long receiverId);
+
+  // Get notifications ordered by creation date ascending (oldest first)
+  @Query("SELECT n FROM Notification n WHERE n.receiverId = :receiverId ORDER BY n.createdAt ASC")
+  List<Notification> findOldestByReceiverId(
+      @Param("receiverId") Long receiverId, Pageable pageable);
+
+  @Modifying
+  @Query("DELETE FROM Notification n WHERE n.createdAt < :cutoffDate")
+  void deleteByCreatedAtBefore(@Param("cutoffDate") LocalDateTime cutoffDate);
+}


### PR DESCRIPTION
Implemented the initial domain design for the Notification feature, strictly focusing on the Entity and Repository layers as requested. Created `NotificationType` and `NotificationCategory` enums to support push settings and various event logic. Designed the `Notification` entity with loose coupling (using IDs instead of strict relations) and `BaseTimeEntity`. Added `NotificationRepository` with querying and deletion methods necessary for the data retention policies (30 days or max 100).

---
*PR created automatically by Jules for task [2325713822169164035](https://jules.google.com/task/2325713822169164035) started by @hwnooy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Notification system infrastructure added to support notifications for friend requests, diary activities, comments, replies, engagement milestones, and challenge updates. Notifications can be marked as read and managed with automatic cleanup capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->